### PR TITLE
Bump mariadb Acorn version

### DIFF
--- a/Acornfile
+++ b/Acornfile
@@ -4,7 +4,7 @@ args: {
 }
 
 services: db: {
-	image: "ghcr.io/acorn-io/mariadb:v1.0.0"
+	image: "ghcr.io/acorn-io/mariadb:v10.11.5-1"
 	serviceArgs: {
 		dbName:   "app"
 		username: "appuser"


### PR DESCRIPTION
To include character restrictions on generated basic auth usernames and passwords.